### PR TITLE
LINEアカウントでログインする機能を追加

### DIFF
--- a/src/app/_components/LineLoginButton/LineLoginButton.tsx
+++ b/src/app/_components/LineLoginButton/LineLoginButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { signIn } from 'next-auth/react';
+import type { JSX, MouseEvent } from 'react';
+
+const handleLogin = async (event: MouseEvent<HTMLButtonElement>) => {
+  event.preventDefault();
+
+  await signIn('line');
+};
+
+export const LineLoginButton = (): JSX.Element => {
+  return (
+    <button
+      type="button"
+      className="dark:focus:ring-[#00c300]/55 mb-2 mr-2 inline-flex items-center rounded-lg bg-[#00c300] px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-[#00c300]/90 focus:ring-4 focus:ring-[#00c300]/50"
+      onClick={handleLogin}
+    >
+      <svg
+        className="-ml-1 mr-2 h-4 w-4"
+        aria-hidden="true"
+        focusable="false"
+        role="img"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+      >
+        <path
+          fill="currentColor"
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1.95-13.3c-.55 0-1.06.26-1.39.66-.1.12-.18.24-.26.38-.08-.14-.16-.26-.26-.38-.33-.4-.84-.66-1.39-.66-1.1 0-2 .9-2 2s.9 2 2 2c.55 0 1.06-.26 1.39-.66.1-.12.18-.24.26-.38.08.14.16.26.26.38.33.4.84.66 1.39.66 1.1 0 2-.9 2-2s-.9-2-2-2zm7.9 0c-.55 0-1.06.26-1.39.66-.1.12-.18.24-.26.38-.08-.14-.16-.26-.26-.38-.33-.4-.84-.66-1.39-.66-1.1 0-2 .9-2 2s.9 2 2 2c.55 0 1.06-.26 1.39-.66.1-.12.18-.24.26-.38.08.14.16.26.26.38.33.4.84.66 1.39.66 1.1 0 2-.9 2-2s-.9-2-2-2zm-7.9 12c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm7.9 0c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"
+        ></path>
+      </svg>
+      sign in with LINE
+    </button>
+  );
+};

--- a/src/app/_components/LineLoginButton/index.ts
+++ b/src/app/_components/LineLoginButton/index.ts
@@ -1,0 +1,1 @@
+export { LineLoginButton } from './LineLoginButton';

--- a/src/app/_components/index.ts
+++ b/src/app/_components/index.ts
@@ -1,3 +1,4 @@
 export { GoogleLoginButton } from './GoogleLoginButton';
+export { LineLoginButton } from './LineLoginButton';
 export { LogoutButton } from './LogoutButton';
 export { UserProfile } from './UserProfile';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import {
   GoogleLoginButton,
+  LineLoginButton,
   LogoutButton,
   UserProfile,
 } from '@/app/_components';
@@ -59,7 +60,10 @@ export default async function Home(): Promise<JSX.Element> {
           <LogoutButton />
         </>
       ) : (
-        <GoogleLoginButton />
+        <span className="isolate inline-flex rounded-md shadow-sm">
+          <GoogleLoginButton />
+          <LineLoginButton />
+        </span>
       )}
     </main>
   );

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -2,6 +2,7 @@ import * as jose from 'jose';
 import type { DefaultSession, NextAuthOptions, Session, User } from 'next-auth';
 import type { DefaultJWT, JWT } from 'next-auth/jwt';
 import GoogleProvider from 'next-auth/providers/google';
+import LineProvider from 'next-auth/providers/line';
 
 declare module 'next-auth' {
   interface Session extends DefaultSession {
@@ -36,6 +37,13 @@ export const options: NextAuthOptions = {
     GoogleProvider({
       clientId: String(process.env.GOOGLE_CLIENT_ID),
       clientSecret: String(process.env.GOOGLE_CLIENT_SECRET),
+    }),
+    LineProvider({
+      clientId: String(process.env.LINE_CLIENT_ID),
+      clientSecret: String(process.env.LINE_CLIENT_SECRET),
+      authorization: {
+        params: { scope: 'openid profile email' },
+      },
     }),
   ],
   callbacks: {


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/next-auth-examples/issues/2

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/keitakn/next-auth-examples/issues/2 のDoneの定義にあるようにLINEアカウントでのログインが実装されている事。

# Storybook の URL、 スクリーンショット

## LINEログイン時の同意画面

<img width="558" alt="authorization" src="https://github.com/keitakn/next-auth-examples/assets/11032365/9732e292-0e20-4269-b73c-a14b847e9579">

# 変更点概要

LINEログインを実装。

https://zenn.dev/link/comments/4d864ca9faa42a

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

インラインコメントに記載。