### PR TITLE
ログイン中のユーザーが別の認証Provider のIDを紐付けられるように改修

### DIFF
--- a/src/app/_components/GoogleLoginButton/GoogleLoginButton.tsx
+++ b/src/app/_components/GoogleLoginButton/GoogleLoginButton.tsx
@@ -4,10 +4,14 @@ import { signIn } from 'next-auth/react';
 import type { JSX, MouseEvent } from 'react';
 
 type Props = {
+  buttonText?: string;
   callbackUrl?: string;
 };
 
-export const GoogleLoginButton = ({ callbackUrl }: Props): JSX.Element => {
+export const GoogleLoginButton = ({
+  buttonText = 'sign in with Google',
+  callbackUrl,
+}: Props): JSX.Element => {
   const handleLogin = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
 
@@ -41,7 +45,7 @@ export const GoogleLoginButton = ({ callbackUrl }: Props): JSX.Element => {
           d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
         ></path>
       </svg>
-      sign in with Google
+      {buttonText}
     </button>
   );
 };

--- a/src/app/_components/LineLoginButton/LineLoginButton.tsx
+++ b/src/app/_components/LineLoginButton/LineLoginButton.tsx
@@ -4,10 +4,14 @@ import { signIn } from 'next-auth/react';
 import type { JSX, MouseEvent } from 'react';
 
 type Props = {
+  buttonText?: string;
   callbackUrl?: string;
 };
 
-export const LineLoginButton = ({ callbackUrl }: Props): JSX.Element => {
+export const LineLoginButton = ({
+  buttonText = 'sign in with LINE',
+  callbackUrl,
+}: Props): JSX.Element => {
   const handleLogin = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
 
@@ -39,7 +43,7 @@ export const LineLoginButton = ({ callbackUrl }: Props): JSX.Element => {
           d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1.95-13.3c-.55 0-1.06.26-1.39.66-.1.12-.18.24-.26.38-.08-.14-.16-.26-.26-.38-.33-.4-.84-.66-1.39-.66-1.1 0-2 .9-2 2s.9 2 2 2c.55 0 1.06-.26 1.39-.66.1-.12.18-.24.26-.38.08.14.16.26.26.38.33.4.84.66 1.39.66 1.1 0 2-.9 2-2s-.9-2-2-2zm7.9 0c-.55 0-1.06.26-1.39.66-.1.12-.18.24-.26.38-.08-.14-.16-.26-.26-.38-.33-.4-.84-.66-1.39-.66-1.1 0-2 .9-2 2s.9 2 2 2c.55 0 1.06-.26 1.39-.66.1-.12.18-.24.26-.38.08.14.16.26.26.38.33.4.84.66 1.39.66 1.1 0 2-.9 2-2s-.9-2-2-2zm-7.9 12c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm7.9 0c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"
         ></path>
       </svg>
-      sign in with LINE
+      {buttonText}
     </button>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,10 +57,10 @@ export default async function Home(): Promise<JSX.Element> {
             email={session.user.email}
             avatarUrl={session.user.image}
           />
-        <span className="isolate inline-flex rounded-md shadow-sm">
-          <GoogleLoginButton buttonText="Googleアカウントを連携" />
-          <LineLoginButton buttonText="LINEアカウントを連携" />
-        </span>
+          <span className="isolate inline-flex rounded-md shadow-sm">
+            <GoogleLoginButton buttonText="Googleアカウントを連携" />
+            <LineLoginButton buttonText="LINEアカウントを連携" />
+          </span>
           <LogoutButton />
         </>
       ) : (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,6 +57,10 @@ export default async function Home(): Promise<JSX.Element> {
             email={session.user.email}
             avatarUrl={session.user.image}
           />
+        <span className="isolate inline-flex rounded-md shadow-sm">
+          <GoogleLoginButton buttonText="Googleアカウントを連携" />
+          <LineLoginButton buttonText="LINEアカウントを連携" />
+        </span>
           <LogoutButton />
         </>
       ) : (


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/next-auth-examples/issues/6

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/keitakn/next-auth-examples/issues/6 のDoneの定義を満たす実装は全てこのPRで完了させる。

# Storybook の URL、 スクリーンショット

<img width="580" alt="LINE_Connect" src="https://github.com/keitakn/next-auth-examples/assets/11032365/2737a9b8-1028-4b3d-9460-2cc06aab3ccc">

# 変更点概要

タイトルの通り、既にログイン済みのユーザーが別の認証Provider のIDを紐付けられるように改修した。

https://zenn.dev/link/comments/75c0c1f76f1c14 に詳しい解説を記載済み。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし