### PR TITLE
メールアドレス未登録のLINEユーザーが登録出来るように対応

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ async function fetchSession(cookie: string): Promise<Session | null> {
 type ValidSession = {
   user: {
     name: string;
-    email: string;
+    email?: string;
     image: string;
   };
   expires: string;
@@ -33,11 +33,7 @@ type ValidSession = {
 function isValidSession(session: Session | null): session is ValidSession {
   if (session) {
     // サンプルコードなので手抜きしているが実際はちゃんと型検査をする
-    if (
-      session.user?.name != null &&
-      session.user.email != null &&
-      session.user.image != null
-    ) {
+    if (session.user?.name != null && session.user.image != null) {
       return true;
     }
   }
@@ -54,7 +50,7 @@ export default async function Home(): Promise<JSX.Element> {
         <>
           <UserProfile
             name={session.user.name}
-            email={session.user.email}
+            email={session.user.email ?? ''}
             avatarUrl={session.user.image}
           />
           <span className="isolate inline-flex rounded-md shadow-sm">

--- a/src/features/auth.ts
+++ b/src/features/auth.ts
@@ -43,6 +43,7 @@ export const options: NextAuthOptions = {
     GoogleProvider({
       clientId: String(process.env.GOOGLE_CLIENT_ID),
       clientSecret: String(process.env.GOOGLE_CLIENT_SECRET),
+      allowDangerousEmailAccountLinking: true,
     }),
     LineProvider({
       clientId: String(process.env.LINE_CLIENT_ID),
@@ -50,6 +51,7 @@ export const options: NextAuthOptions = {
       authorization: {
         params: { scope: 'openid profile email' },
       },
+      allowDangerousEmailAccountLinking: true,
     }),
   ],
   // 必要に応じて https://next-auth.js.org/configuration/pages を参考に各ページをオーバーライドする


### PR DESCRIPTION
# issueURL

https://github.com/keitakn/next-auth-examples/issues/12

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/keitakn/next-auth-examples/issues/12 のDoneの定義を満たす実装は全てこのPRで対応する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

以下の2点を対応しました。

## メールアドレスが未登録のユーザーでもLINEログインが実行可能なように改修

メールアドレスを任意項目として扱う事でメールアドレスを持たないユーザーでもLINEログインによる登録を可能にしました。

Googleに関しても理論上は登録可能ですがGoogleアカウントはGmailがあるのでメールアドレスなしというパターンは考えにくいと思われます。

詳しい対応内容は以下にまとめています。

https://zenn.dev/link/comments/8e4997c464a4e8

## 同じメールアドレスで別の認証Providerでログインを実行した場合、同一人物と見なす対応

詳しい調査結果は https://zenn.dev/link/comments/513d2952d24a70 のコメントに記載しています。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし